### PR TITLE
Add nofollow on nav links for the 3 sites

### DIFF
--- a/src/api/ousd/content-types/ousd-nav-link/schema.json
+++ b/src/api/ousd/content-types/ousd-nav-link/schema.json
@@ -45,6 +45,11 @@
       ],
       "required": true,
       "default": "_self"
+    },
+    "nofollow": {
+      "type": "boolean",
+      "default": false,
+      "required": true
     }
   }
 }

--- a/src/api/story/content-types/story-nav-link/schema.json
+++ b/src/api/story/content-types/story-nav-link/schema.json
@@ -48,6 +48,11 @@
       ],
       "default": "_self",
       "required": true
+    },
+    "nofollow": {
+      "type": "boolean",
+      "default": false,
+      "required": true
     }
   }
 }

--- a/src/api/website/content-types/website-nav-link/schema.json
+++ b/src/api/website/content-types/website-nav-link/schema.json
@@ -80,6 +80,16 @@
       ],
       "default": "_self",
       "required": true
+    },
+    "nofollow": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "type": "boolean",
+      "default": false,
+      "required": true
     }
   }
 }

--- a/src/components/shared/nav-link.json
+++ b/src/components/shared/nav-link.json
@@ -54,6 +54,11 @@
       ],
       "default": "_self",
       "required": true
+    },
+    "nofollow": {
+      "type": "boolean",
+      "default": false,
+      "required": true
     }
   }
 }


### PR DESCRIPTION
We need to be able to specify whether a given link should have `rel=nofollow` or not, based on whether we endorse the contents of the linked document. For our links, we shouldn't have it, and for external links, like to exchanges, we should. 

Because we are linking to properties across all 3 sites and old versions of each of the 3 sites, and because we don't need other `rel` types as far as I can tell (see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel for more), I added it as a boolean value.