### PR TITLE
Nickick/remove media types

### DIFF
--- a/src/api/blog/content-types/ousd-post/schema.json
+++ b/src/api/blog/content-types/ousd-post/schema.json
@@ -50,9 +50,7 @@
       "multiple": false,
       "required": false,
       "allowedTypes": [
-        "images",
-        "files",
-        "videos"
+        "images"
       ],
       "pluginOptions": {
         "i18n": {

--- a/src/api/blog/content-types/story-post/schema.json
+++ b/src/api/blog/content-types/story-post/schema.json
@@ -50,9 +50,7 @@
       "multiple": false,
       "required": false,
       "allowedTypes": [
-        "images",
-        "files",
-        "videos"
+        "images"
       ],
       "pluginOptions": {
         "i18n": {

--- a/src/api/blog/content-types/website-post/schema.json
+++ b/src/api/blog/content-types/website-post/schema.json
@@ -50,9 +50,7 @@
       "multiple": false,
       "required": false,
       "allowedTypes": [
-        "images",
-        "files",
-        "videos"
+        "images"
       ],
       "pluginOptions": {
         "i18n": {

--- a/src/api/global/content-types/global/schema.json
+++ b/src/api/global/content-types/global/schema.json
@@ -21,9 +21,7 @@
       "multiple": false,
       "required": false,
       "allowedTypes": [
-        "images",
-        "files",
-        "videos"
+        "images"
       ]
     },
     "siteDescription": {

--- a/src/components/shared/seo.json
+++ b/src/components/shared/seo.json
@@ -23,9 +23,7 @@
       "multiple": false,
       "required": true,
       "allowedTypes": [
-        "images",
-        "files",
-        "videos"
+        "images"
       ]
     },
     "metaSocial": {

--- a/src/utils/sanitize.js
+++ b/src/utils/sanitize.js
@@ -8,7 +8,7 @@ function sanitizePost(post) {
   }
 
   return {
-    ...pick(post, ['title', 'body', 'slug', 'locale', 'publishedAt', 'updatedAt']),
+    ...pick(post, ['title', 'body', 'slug', 'locale', 'publishedAt', 'updatedAt', 'publishBackdate']),
     cover: sanitizeMedia(post.cover),
     cardCover: sanitizeMedia(post.cardCover),
     category: sanitizeCategory(post.category),


### PR DESCRIPTION
Removes `media` and `videos` from `cover` collection fields.