### PR TITLE
configure sentry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,5 @@ STORY_HOST=https://story.xyz
 AWS_BUCKET=tobemodified
 AWS_ACCESS_KEY_ID=tobemodified
 AWS_SECRET=tobemodified
+
+SENTRY_DSN=

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -97,4 +97,10 @@ module.exports = ({ env }) => ({
   menus: {
     enabled: false,
   },
+  sentry: {
+    enabled: true,
+    config: {
+      dsn: env('NODE_ENV') === 'production' ? env('SENTRY_DSN') : null,
+    },
+  },
 });

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -19,6 +19,8 @@ const localConfig = {
   provider: 'local',
 };
 
+const environment = env('NODE_ENV') === 'production' ? env(APP_ENV) : 'development';
+
 module.exports = ({ env }) => ({
   email: {
     config: {
@@ -99,8 +101,9 @@ module.exports = ({ env }) => ({
   },
   sentry: {
     enabled: true,
+    environment: environment,
     config: {
-      dsn: env('NODE_ENV') === 'production' ? env('SENTRY_DSN') : null,
+      dsn: env('SENTRY_DSN'),
     },
   },
 });

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "@_sh/strapi-plugin-ckeditor": "^1.1.2",
     "@strapi/plugin-graphql": "^4.0.5",
     "@strapi/plugin-i18n": "^4.4.5",
+    "@strapi/plugin-sentry": "^4.5.6",
     "@strapi/plugin-seo": "^1.7.5",
     "@strapi/plugin-users-permissions": "4.3.9",
     "@strapi/provider-email-sendgrid": "^4.3.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2136,6 +2136,13 @@
     "@strapi/utils" "4.4.5"
     lodash "4.17.21"
 
+"@strapi/plugin-sentry@^4.5.6":
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/@strapi/plugin-sentry/-/plugin-sentry-4.5.6.tgz#526cd9a2928a559406d66a5b2995553684f734c4"
+  integrity sha512-9dibzr4+zPPjb74asE+AEtGsJOE1ke0wmIphByVAb6CgyzK8sP6LFhnuybNcZRV6I2PWwJY3N70AB4zH4CIR5A==
+  dependencies:
+    "@sentry/node" "6.19.7"
+
 "@strapi/plugin-seo@^1.7.5":
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/@strapi/plugin-seo/-/plugin-seo-1.7.5.tgz#74a7395c56d40f814ce553d8e902e2cfbe6154f3"


### PR DESCRIPTION
Configure sentry for cms. Not sure if the Strapi plugin supports differentiating between staging and production environments. Might have to disable on staging or add another Sentry project if needed

SENTRY_DSN=https://0fa190a6d7e3478b88a4fb4a68e971ee@o225462.ingest.sentry.io/4504001035632640